### PR TITLE
checking for empty result set

### DIFF
--- a/src/Model/Behavior/CryptBehavior.php
+++ b/src/Model/Behavior/CryptBehavior.php
@@ -94,29 +94,32 @@ class CryptBehavior extends Behavior
      */
     public function findDecrypted(Query $query, array $options)
     {
-        $options += ['fields' => []];
-        $mapper = function ($row) use ($options) {
-            $driver = $this->_table->connection()->driver();
-            foreach ($this->config('fields') as $field => $type) {
-                if (($options['fields'] && !in_array($field, (array)$options['fields']))
-                    || !$row->has($field)
-                ) {
-                    continue;
+        if(!$query->isEmpty()) {
+            $options += ['fields' => []];
+            $mapper = function ($row) use ($options) {
+                $driver = $this->_table->connection()->driver();
+                foreach ($this->config('fields') as $field => $type) {
+                    if (($options['fields'] && !in_array($field, (array)$options['fields']))
+                        || !$row->has($field)
+                    ) {
+                        continue;
+                    }
+
+                    $cipher = $row->get($field);
+                    $plain = $this->decrypt($cipher);
+                    $row->set($field, Type::build($type)->toPHP($plain, $driver));
                 }
 
-                $cipher = $row->get($field);
-                $plain = $this->decrypt($cipher);
-                $row->set($field, Type::build($type)->toPHP($plain, $driver));
-            }
+                return $row;
+            };
 
-            return $row;
-        };
+            $formatter = function ($results) use ($mapper) {
+                return $results->map($mapper);
+            };
 
-        $formatter = function ($results) use ($mapper) {
-            return $results->map($mapper);
-        };
-
-        return $query->formatResults($formatter);
+            return $query->formatResults($formatter);
+        }
+        return $query;
     }
 
     /**

--- a/src/Model/Behavior/CryptBehavior.php
+++ b/src/Model/Behavior/CryptBehavior.php
@@ -94,7 +94,7 @@ class CryptBehavior extends Behavior
      */
     public function findDecrypted(Query $query, array $options)
     {
-        if(!$query->isEmpty()) {
+        if(!$query->isEmpty() && $query->isHydrationEnabled()) {
             $options += ['fields' => []];
             $mapper = function ($row) use ($options) {
                 $driver = $this->_table->connection()->driver();

--- a/src/Model/Behavior/CryptBehavior.php
+++ b/src/Model/Behavior/CryptBehavior.php
@@ -94,7 +94,7 @@ class CryptBehavior extends Behavior
      */
     public function findDecrypted(Query $query, array $options)
     {
-        if(!$query->isEmpty() && $query->isHydrationEnabled()) {
+        if ($query->isHydrationEnabled()) {
             $options += ['fields' => []];
             $mapper = function ($row) use ($options) {
                 $driver = $this->_table->connection()->driver();
@@ -114,7 +114,10 @@ class CryptBehavior extends Behavior
             };
 
             $formatter = function ($results) use ($mapper) {
-                return $results->map($mapper);
+                if (!$results->isEmpty()) {
+                    return $results->map($mapper);
+                }
+                return $results;
             };
 
             return $query->formatResults($formatter);


### PR DESCRIPTION
The findDecrypted method fails when the result set is empty. This is because of the has() check. I propose a check for empty before trying to decrypt. 