### PR TITLE
Check that $row is not a string or array

### DIFF
--- a/src/Model/Behavior/CryptBehavior.php
+++ b/src/Model/Behavior/CryptBehavior.php
@@ -99,7 +99,7 @@ class CryptBehavior extends Behavior
             $driver = $this->_table->connection()->driver();
             foreach ($this->config('fields') as $field => $type) {
                 if (($options['fields'] && !in_array($field, (array)$options['fields']))
-                    || is_string($row) || (is_array($row) ? !isset($row[$field]) : !$row->has($field))
+                    || !($row instanceof EntityInterface) || !$row->has($field)
                 ) {
                     continue;
                 }

--- a/src/Model/Behavior/CryptBehavior.php
+++ b/src/Model/Behavior/CryptBehavior.php
@@ -99,7 +99,7 @@ class CryptBehavior extends Behavior
             $driver = $this->_table->connection()->driver();
             foreach ($this->config('fields') as $field => $type) {
                 if (($options['fields'] && !in_array($field, (array)$options['fields']))
-                    || !$row->has($field)
+                    || is_string($row) || (is_array($row) ? !isset($row[$field]) : !$row->has($field))
                 ) {
                     continue;
                 }


### PR DESCRIPTION
Bypass the $row->has() test in the case that the $row is actually a string or an array. The rules checker ExistsIn method will return the row as an array, the “list” finder will return the $row as a string. Both will return a fatal error when $row->has() is called in the Crypt Behavior.